### PR TITLE
Adding NVRAM entries manually to support secureboot

### DIFF
--- a/debian-buster-zfs-root.sh
+++ b/debian-buster-zfs-root.sh
@@ -302,7 +302,7 @@ if [ "$GRUBTYPE" == "$EFI" ]; then
 		done < <(efibootmgr | grep "$BOOTLOADERID" | sed "s/^Boot\(....\).*$/\1/g")
 
 		# Add EFI entry for this disk
-		efibootmgr -c --label "$BOOTLOADERID" --loader "\EFI\debian\grubx64.efi" --disk "$EFIPARTITION" --part $PARTEFI
+		efibootmgr -c --label "$BOOTLOADERID" --loader "\EFI\debian\shimx64.efi" --disk "$EFIPARTITION" --part $PARTEFI
 
 		if [ $I -gt 0 ]; then
 			EFIBAKPART="#"


### PR DESCRIPTION
The grub efi file signed by debian has a hardcoded path pointing to \EFI\debian\grub.cfg, so we need to install grub to this location. Then we would have two entries named "debian" in our boot menu and don't which one is for which disk. To overcome this issue we manually add the correctly labled entries using efibootmgr to our NVRAM.

This will fix issue: https://github.com/hn/debian-buster-zfs-root/issues/3