### PR TITLE
Make menu prompts detail single disk configurations

### DIFF
--- a/debian-buster-zfs-root.sh
+++ b/debian-buster-zfs-root.sh
@@ -37,6 +37,8 @@ SIZESWAP=2G
 SIZETMP=3G
 SIZEVARTMP=3G
 
+NEWHOST="" #Manually specify hostname of new install, otherwise it will be generated
+
 ### User settings
 
 declare -A BYID
@@ -224,8 +226,9 @@ zpool status
 zfs list
 
 debootstrap --include=openssh-server,locales,linux-headers-amd64,linux-image-amd64,joe,rsync,sharutils,psmisc,htop,patch,less --components main,contrib,non-free $TARGETDIST /target http://deb.debian.org/debian/
-
-NEWHOST=debian-$(hostid)
+if [ "$NEWHOST" == "" ]; then
+	NEWHOST=debian-$(hostid)
+fi
 echo "$NEWHOST" >/target/etc/hostname
 sed -i "1s/^/127.0.1.1\t$NEWHOST\n/" /target/etc/hosts
 

--- a/debian-buster-zfs-root.sh
+++ b/debian-buster-zfs-root.sh
@@ -54,7 +54,7 @@ done
 
 TMPFILE=$(mktemp)
 whiptail --backtitle "$0" --title "Drive selection" --separate-output \
-	--checklist "\nPlease select ZFS RAID drives\n" 20 74 8 "${SELECT[@]}" 2>"$TMPFILE"
+	--checklist "\nPlease select ZFS drives\n" 20 74 8 "${SELECT[@]}" 2>"$TMPFILE"
 
 if [ $? -ne 0 ]; then
 	exit 1
@@ -74,7 +74,7 @@ done < "$TMPFILE"
 
 whiptail --backtitle "$0" --title "RAID level selection" --separate-output \
 	--radiolist "\nPlease select ZFS RAID level\n" 20 74 8 \
-	"RAID0" "Striped disks" off \
+	"RAID0" "Striped disks or single disk" off \
 	"RAID1" "Mirrored disks (RAID10 for n>=4)" on \
 	"RAIDZ" "Distributed parity, one parity block" off \
 	"RAIDZ2" "Distributed parity, two parity blocks" off \

--- a/debian-buster-zfs-root.sh
+++ b/debian-buster-zfs-root.sh
@@ -40,6 +40,7 @@ SIZEVARTMP=3G
 NEWHOST="" #Manually specify hostname of new install, otherwise it will be generated
 NEWDNS="nameserver 8.8.8.8\nnameserver 8.8.4.4"
 NOSWAP="" #Set NOSWAP to be something other than "" and no SWAP dataset will be created/used
+NEWPATH=$PATH
 
 ### User settings
 
@@ -317,6 +318,7 @@ do
   sleep 2
 done
 
+chroot /target /bin/bash -c "export PATH=$NEWPATH" #Exporting root PATH to root on new system
 chroot /target /usr/sbin/dpkg-reconfigure tzdata
 
 sync

--- a/debian-buster-zfs-root.sh
+++ b/debian-buster-zfs-root.sh
@@ -38,6 +38,8 @@ SIZETMP=3G
 SIZEVARTMP=3G
 
 NEWHOST="" #Manually specify hostname of new install, otherwise it will be generated
+NEWDNS="nameserver 8.8.8.8\nnameserver 8.8.4.4"
+
 
 ### User settings
 
@@ -286,11 +288,13 @@ if [ -d /proc/acpi ]; then
 	chroot /target /usr/bin/apt-get install --yes acpi acpid
 	chroot /target service acpid stop
 fi
-
-ETHDEV=$(udevadm info -e | grep "ID_NET_NAME_PATH=" | head -n1 | cut -d= -f2)
+ETHDEV=$(udevadm info -e | grep "ID_NET_NAME_ONBOARD=" | head -n1 | cut -d= -f2) #Selects 1st onboard NIC, if present
+if [ "$ETHDEV" == "" ] ; then
+	ETHDEV=$(udevadm info -e | grep "ID_NET_NAME_PATH=" | head -n1 | cut -d= -f2) #Selects 1st addin NIC, if present
+fi
 test -n "$ETHDEV" || ETHDEV=enp0s1
 echo -e "\nauto $ETHDEV\niface $ETHDEV inet dhcp\n" >>/target/etc/network/interfaces
-echo -e "nameserver 8.8.8.8\nnameserver 8.8.4.4" >> /target/etc/resolv.conf
+echo -e "$NEWDNS" >> /target/etc/resolv.conf
 
 chroot /target /usr/bin/passwd
 chroot /target /usr/sbin/dpkg-reconfigure tzdata

--- a/debian-buster-zfs-root.sh
+++ b/debian-buster-zfs-root.sh
@@ -311,7 +311,12 @@ test -n "$ETHDEV" || ETHDEV=enp0s1
 echo -e "\nauto $ETHDEV\niface $ETHDEV inet dhcp\n" >>/target/etc/network/interfaces
 echo -e "$NEWDNS" >> /target/etc/resolv.conf
 
-chroot /target /usr/bin/passwd
+until chroot /target /usr/bin/passwd
+do
+  echo "Try again"
+  sleep 2
+done
+
 chroot /target /usr/sbin/dpkg-reconfigure tzdata
 
 sync


### PR DESCRIPTION
Disk and raid level selection prompts don't make it clear what to do for a single disk (e.g. a boot ssd). Removed "RAID" from the disk selection prompt and added "..or single disk" to the RAID0 description.