### PR TITLE
Update debian-buster-zfs-root.sh

### DIFF
--- a/debian-buster-zfs-root.sh
+++ b/debian-buster-zfs-root.sh
@@ -204,7 +204,7 @@ zfs create $ZPOOL/ROOT
 zfs create -o mountpoint=/ $ZPOOL/ROOT/debian-$TARGETDIST
 zpool set bootfs=$ZPOOL/ROOT/debian-$TARGETDIST $ZPOOL
 
-zfs create -o mountpoint=/tmp -o setuid=off -o exec=off -o devices=off -o com.sun:auto-snapshot=false -o quota=$SIZETMP $ZPOOL/tmp
+zfs create -o mountpoint=/tmp -o setuid=off -o devices=off -o com.sun:auto-snapshot=false -o quota=$SIZETMP $ZPOOL/tmp
 chmod 1777 /target/tmp
 
 # /var needs to be mounted via fstab, the ZFS mount script runs too late during boot


### PR DESCRIPTION
Can't exec "/tmp/zfs-dkms.config.bjN4dj": Permission denied at /usr/lib/x86_64-linux-gnu/perl-base/IPC/Open3.pm line 178.